### PR TITLE
LPS-200683 Update also article's assetDisplayPageEntry in case there is one associated

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6163,6 +6163,23 @@ public class JournalArticleLocalServiceImpl
 				journalArticleLocalService.updateStatus(
 					userId, article.getId(), WorkflowConstants.STATUS_APPROVED,
 					new HashMap<>(), serviceContext);
+
+				AssetDisplayPageEntry assetDisplayPageEntry =
+					_assetDisplayPageEntryLocalService.
+						fetchAssetDisplayPageEntry(
+							article.getGroupId(),
+							_classNameLocalService.getClassNameId(
+								JournalArticle.class),
+							article.getResourcePrimKey());
+
+				if (assetDisplayPageEntry != null) {
+					_assetDisplayPageEntryLocalService.
+						updateAssetDisplayPageEntry(
+							assetDisplayPageEntry.getAssetDisplayPageEntryId(),
+							assetDisplayPageEntry.
+								getLayoutPageTemplateEntryId(),
+							assetDisplayPageEntry.getType());
+				}
 			});
 		actionableDynamicQuery.setTransactionConfig(
 			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);


### PR DESCRIPTION
Hello team, this commit fixes the case described in https://liferay.atlassian.net/browse/LPS-200683, observed by a customer within their prod environment, so it's quite urgent for them:

1. Define Check Interval value to 1 in _System Properties -> Web Content -> Virtual Instance Scope -> Web Content -> Check Interval_
2. Create a display page template for basic web contents
3. Add a new basic web content 'test':

> - Select the dpt created previously
> - Select the display date to 2 minutes later.

5. Wait until the article is approved.
6. Check article's friendly URL. In my case: localhost:8080/web/guest/w/test

**Expected result:** the wc is shown

**Current result:** a not found 404 page is shown.

*If you publish manually the article or you click on the preview option from the dpt section, the above URL shows the article correctly.

Since AssetDisplayPageEntry table shows a plid = 0 for the entry related to the article even after it being approved, I considered that updating its assetDisplayPageEntry (if any), just like it's done when adding a draft or publishing it directly, could be an option. I'm not sure this is the best or most efficient way  to achieve the expected result, so please let me know if you need me to rethink this.

Thanks in advance :)
